### PR TITLE
AutoLayoutの設定

### DIFF
--- a/Swift5IntroApp1.xcworkspace/xcuserdata/user.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Swift5IntroApp1.xcworkspace/xcuserdata/user.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "5D0724DC-9478-49FD-BC36-C224AA0CADAC"
    type = "0"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "1FC99B5F-0266-4C42-A36A-4FAEB9DB3126"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Swift5IntroApp1/Controller/BaseViewController.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "53"
-            endingLineNumber = "53"
-            landmarkName = "segementSlideHeaderView()"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/Swift5IntroApp1/Controller/BaseViewController.swift
+++ b/Swift5IntroApp1/Controller/BaseViewController.swift
@@ -26,14 +26,13 @@ class BaseViewController: SegementSlideDefaultViewController{
     }
 
     
-    //この辺りの理解がまだ少し弱いです。ビューやボタンの配置（AutoLayout）について学習を進めます
     override func segementSlideHeaderView() -> UIView {
 
         let headerView = UIImageView()
 
         headerView.isUserInteractionEnabled = true
 
-        headerView.contentMode = .scaleAspectFill
+        headerView.contentMode = .scaleToFill
 
         headerView.image = UIImage(named: "header")
 

--- a/Swift5IntroApp1/Controller/IntroViewController.swift
+++ b/Swift5IntroApp1/Controller/IntroViewController.swift
@@ -26,7 +26,9 @@ class IntroViewController: UIViewController, UIScrollViewDelegate{
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        // ボタンの横幅に応じてフォントサイズを自動調整する設定
+            skipButton.titleLabel?.adjustsFontSizeToFitWidth = true
         //ページングしたいのでTrueに設定
         scrollView.isPagingEnabled = true
         
@@ -35,7 +37,7 @@ class IntroViewController: UIViewController, UIScrollViewDelegate{
         
         animationLottie()
         
-        
+                
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -87,6 +89,19 @@ class IntroViewController: UIViewController, UIScrollViewDelegate{
                                                             multiplier: 0.1,
                                                             constant: 0)
         self.view.addConstraint(skipButtonHeightConstraint)
+        
+        
+        
+        removeAllSubViews(parentView: scrollView)
+        setUpScroll()
+        animationLottie()
+    }
+    
+    func removeAllSubViews(parentView:UIView){
+        let subviews = parentView.subviews
+        for subview in subviews {
+            subview.removeFromSuperview()
+        }
     }
     
     

--- a/Swift5IntroApp1/Controller/IntroViewController.swift
+++ b/Swift5IntroApp1/Controller/IntroViewController.swift
@@ -14,37 +14,27 @@ class IntroViewController: UIViewController, UIScrollViewDelegate{
     
     @IBOutlet weak var scrollView: UIScrollView!
     
+    @IBOutlet weak var skipButton: UIButton!
+    
     //アニメーションさせるJsonの配列
     var onboardArray = ["1","2","3","4","5"]
     
     //アニメーションの下に表示される文字列の配列
     var onboardStringArray = ["aaaa","iiii","uuuu","eeee","oooo"]
     
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
         //ページングしたいのでTrueに設定
         scrollView.isPagingEnabled = true
-
+        
         //アニメーション置き場生成
         setUpScroll()
         
-        //Lottieを使ってアニメーションさせる
-        for i in 0...4{
-            
-            let animationView = AnimationView()
-            let animation = Animation.named(onboardArray[i])
-            animationView.frame = CGRect(x: CGFloat(i) * view.frame.size.width,
-                                         y: 0,
-                                         width: view.frame.size.width,
-                                         height: view.frame.size.height)
-            animationView.animation = animation
-            animationView.contentMode = .scaleAspectFit
-            animationView.loopMode = .loop
-            animationView.play()
-            scrollView.addSubview(animationView)
-            
-        }
+        animationLottie()
+        
         
     }
     
@@ -53,7 +43,52 @@ class IntroViewController: UIViewController, UIScrollViewDelegate{
         
         //ナビゲーションバーを消す
         self.navigationController?.isNavigationBarHidden = true
+        
+        
     }
+    
+    override func viewDidLayoutSubviews() {
+        
+        //スキップボタンの制約設定
+        skipButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        let skipButtonTopConstraint = NSLayoutConstraint(item: skipButton as Any,
+                                                         attribute: NSLayoutConstraint.Attribute.top,
+                                                         relatedBy: NSLayoutConstraint.Relation.equal,
+                                                         toItem: self.view,
+                                                         attribute: NSLayoutConstraint.Attribute.top,
+                                                         multiplier: 1.0,
+                                                         constant: 50)
+        self.view.addConstraint(skipButtonTopConstraint)
+        
+        let skipButtonLeadingConstraint = NSLayoutConstraint(item: skipButton as Any,
+                                                             attribute: NSLayoutConstraint.Attribute.leading,
+                                                             relatedBy: NSLayoutConstraint.Relation.equal,
+                                                             toItem: self.view,
+                                                             attribute: NSLayoutConstraint.Attribute.leading,
+                                                             multiplier: 1.0,
+                                                             constant: 20)
+        self.view.addConstraint(skipButtonLeadingConstraint)
+        
+        let skipButtonWidthConstraint = NSLayoutConstraint(item: skipButton as Any,
+                                                           attribute: NSLayoutConstraint.Attribute.width,
+                                                           relatedBy: NSLayoutConstraint.Relation.equal,
+                                                           toItem: self.view,
+                                                           attribute: NSLayoutConstraint.Attribute.width,
+                                                           multiplier: 0.25,
+                                                           constant: 0)
+        self.view.addConstraint(skipButtonWidthConstraint)
+        
+        let skipButtonHeightConstraint = NSLayoutConstraint(item: skipButton as Any,
+                                                            attribute: NSLayoutConstraint.Attribute.height,
+                                                            relatedBy: NSLayoutConstraint.Relation.equal,
+                                                            toItem: self.view,
+                                                            attribute: NSLayoutConstraint.Attribute.height,
+                                                            multiplier: 0.1,
+                                                            constant: 0)
+        self.view.addConstraint(skipButtonHeightConstraint)
+    }
+    
     
     func setUpScroll(){
         
@@ -62,23 +97,63 @@ class IntroViewController: UIViewController, UIScrollViewDelegate{
         //scrollViewの枠の大きさを、親のViewの大きさと同じにして配置する。
         scrollView.frame = CGRect(x: 0, y: 0, width: view.bounds.size.width, height: view.bounds.size.height)
         
-        scrollView.contentSize = CGSize(width: view.frame.size.width * 5,
-                                        height: view.frame.size.height)
-        //contentSizeの横幅　＝ view.frame.size.width　* （表示したい要素の数分！）という認識。。。
+        scrollView.contentSize = CGSize(width: view.bounds.size.width
+                                            * CGFloat(onboardArray.count),
+                                        height: view.bounds.size.height)
+        print(onboardStringArray.count)
         
-        //jsonファイルの置き場所用意
         for i in 0...4{
             
-            let onboardLabel = UILabel(frame: CGRect(x: CGFloat(i) * view.frame.size.width,
-                                                     y: view.frame.size.height / 3,
-                                                     width: scrollView.frame.size.width,
-                                                     height: scrollView.frame.size.height)
-            )
+            let onboardLabel = UILabel(frame: CGRect(x: CGFloat(i) * view.bounds.size.width,
+                                                     y:view.bounds.size.height / 3,
+                                                     width: scrollView.bounds.size.width,
+                                                     height: scrollView.bounds.size.height))
             
-            onboardLabel.font = UIFont.systemFont(ofSize: 15.0)
+//            onboardLabel.backgroundColor = .red
             onboardLabel.textAlignment = .center
             onboardLabel.text = onboardStringArray[i]
+            onboardLabel.font = UIFont.boldSystemFont(ofSize: 15.0)
+            
             scrollView.addSubview(onboardLabel)
+            
+            
+        }
+        
+//        scrollView.backgroundColor = .blue
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        
+        //scrollViewの制約
+        //scrollViewの横方向の中心は、親ビューの横方向の中心と同じ
+        scrollView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        //scrollViewの縦方向の中心は、親ビューの縦方向の中心と同じ
+        scrollView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
+        
+        // scrollViewの横幅は、親ビューの幅と同じ
+        scrollView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 1).isActive = true
+        // scrollViewの縦幅は、親ビューの幅と同じ
+        scrollView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 1).isActive = true
+        
+    }
+    
+    
+    fileprivate func animationLottie() {
+        //Lottieを使ってアニメーションさせる
+        for i in 0...4{
+            
+            let animationView = AnimationView()
+            let animation = Animation.named(onboardArray[i])
+            animationView.frame = CGRect(x: CGFloat(i) * view.bounds.size.width,
+                                         y: scrollView.bounds.minY,
+                                         width: view.bounds.size.width,
+                                         height: view.bounds.size.height)
+            animationView.animation = animation
+            animationView.contentMode = .scaleAspectFit
+            animationView.loopMode = .loop
+            animationView.play()
+            scrollView.addSubview(animationView)
+        
+            
+            
             
         }
         

--- a/Swift5IntroApp1/Controller/LoginMovieViewController.swift
+++ b/Swift5IntroApp1/Controller/LoginMovieViewController.swift
@@ -18,15 +18,85 @@ class LoginMovieViewController: UIViewController {
     let path = Bundle.main.path(forResource: "start", ofType: "mov")
 
     override func viewDidLoad() {
-        super.viewDidLoad()
         
-        blurView.frame = CGRect(x: 0, y: 0, width: view.bounds.size.width, height: view.bounds.size.height)
+        super.viewDidLoad()
 
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        
+        super.viewWillAppear(animated)
+        
+        self.navigationController?.isNavigationBarHidden = false
+        
+        setUpMoviePlayer()
+        
+    }
+    
+    override func viewDidLayoutSubviews() {
+        
+        //blurViewの制約を設定
+        blurView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let blurViewTopConstraint =
+            NSLayoutConstraint(item: blurView as Any,
+                               attribute: NSLayoutConstraint.Attribute.top,
+                               relatedBy: NSLayoutConstraint.Relation.equal,
+                               toItem: self.view,
+                               attribute: NSLayoutConstraint.Attribute.top,
+                               multiplier: 1.0,
+                               constant: 0)
+
+        self.view.addConstraint(blurViewTopConstraint)
+        
+        let blurViewLeadingConstraint =
+            NSLayoutConstraint(item: blurView as Any,
+                               attribute: NSLayoutConstraint.Attribute.leading,
+                               relatedBy: NSLayoutConstraint.Relation.equal,
+                               toItem: self.view,
+                               attribute: NSLayoutConstraint.Attribute.leading,
+                               multiplier: 1.0,
+                               constant: 0)
+        
+        self.view.addConstraint(blurViewLeadingConstraint)
+        
+        let blurViewBottomConstraint =
+            NSLayoutConstraint(item: blurView as Any,
+                               attribute: NSLayoutConstraint.Attribute.bottom,
+                               relatedBy: NSLayoutConstraint.Relation.equal,
+                               toItem: self.view,
+                               attribute: NSLayoutConstraint.Attribute.bottom,
+                               multiplier: 1.0,
+                               constant: 0)
+        
+        self.view.addConstraint(blurViewBottomConstraint)
+        
+        
+        let blurViewTralingConstraint =
+            NSLayoutConstraint(item: blurView as Any,
+                               attribute: NSLayoutConstraint.Attribute.trailing,
+                               relatedBy: NSLayoutConstraint.Relation.equal,
+                               toItem: self.view,
+                               attribute: NSLayoutConstraint.Attribute.trailing,
+                               multiplier: 1.0,
+                               constant: 0)
+        
+        self.view.addConstraint(blurViewTralingConstraint)
+        
+        
+        
+    }
+    
+    func setUpMoviePlayer(){
+        
         player = AVPlayer(url: URL(fileURLWithPath: path!))
         
         //AVPlayer用のレイヤー作成
         let playerLayer = AVPlayerLayer(player: player)
-        playerLayer.frame = CGRect(x: 0, y: 0, width: view.frame.size.width, height: view.frame.size.height)
+        playerLayer.frame = CGRect(x: 0,
+                                   y: 0,
+                                   width: view.frame.size.width,
+                                   height: view.frame.size.height)
         playerLayer.videoGravity = .resizeAspectFill
         playerLayer.repeatCount = 0
         playerLayer.zPosition = -1
@@ -34,14 +104,6 @@ class LoginMovieViewController: UIViewController {
         
         self.player.isMuted = true
         self.player.play()
-        
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        
-        super.viewWillAppear(animated)
-        
-        self.navigationController?.isNavigationBarHidden = true
         
     }
     

--- a/Swift5IntroApp1/Controller/LoginMovieViewController.swift
+++ b/Swift5IntroApp1/Controller/LoginMovieViewController.swift
@@ -40,10 +40,10 @@ class LoginMovieViewController: UIViewController {
         
         let blurViewTopConstraint =
             NSLayoutConstraint(item: blurView as Any,
-                               attribute: NSLayoutConstraint.Attribute.top,
-                               relatedBy: NSLayoutConstraint.Relation.equal,
+                               attribute: .top,
+                               relatedBy: .equal,
                                toItem: self.view,
-                               attribute: NSLayoutConstraint.Attribute.top,
+                               attribute: .top,
                                multiplier: 1.0,
                                constant: 0)
 
@@ -51,10 +51,10 @@ class LoginMovieViewController: UIViewController {
         
         let blurViewLeadingConstraint =
             NSLayoutConstraint(item: blurView as Any,
-                               attribute: NSLayoutConstraint.Attribute.leading,
-                               relatedBy: NSLayoutConstraint.Relation.equal,
+                               attribute: .leading,
+                               relatedBy: .equal,
                                toItem: self.view,
-                               attribute: NSLayoutConstraint.Attribute.leading,
+                               attribute: .leading,
                                multiplier: 1.0,
                                constant: 0)
         
@@ -62,10 +62,10 @@ class LoginMovieViewController: UIViewController {
         
         let blurViewBottomConstraint =
             NSLayoutConstraint(item: blurView as Any,
-                               attribute: NSLayoutConstraint.Attribute.bottom,
-                               relatedBy: NSLayoutConstraint.Relation.equal,
+                               attribute: .bottom,
+                               relatedBy: .equal,
                                toItem: self.view,
-                               attribute: NSLayoutConstraint.Attribute.bottom,
+                               attribute: .bottom,
                                multiplier: 1.0,
                                constant: 0)
         
@@ -74,10 +74,10 @@ class LoginMovieViewController: UIViewController {
         
         let blurViewTralingConstraint =
             NSLayoutConstraint(item: blurView as Any,
-                               attribute: NSLayoutConstraint.Attribute.trailing,
-                               relatedBy: NSLayoutConstraint.Relation.equal,
+                               attribute: .trailing,
+                               relatedBy: .equal,
                                toItem: self.view,
-                               attribute: NSLayoutConstraint.Attribute.trailing,
+                               attribute: .trailing,
                                multiplier: 1.0,
                                constant: 0)
         
@@ -112,15 +112,5 @@ class LoginMovieViewController: UIViewController {
         player.pause()
         
     }
-    
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }

--- a/Swift5IntroApp1/Controller/LoginMovieViewController.swift
+++ b/Swift5IntroApp1/Controller/LoginMovieViewController.swift
@@ -10,17 +10,44 @@
 import UIKit
 import AVFoundation
 
-class LoginMovieViewController: UIViewController {
+class LoginMovieViewController: UIViewController{
     
     @IBOutlet weak var blurView: UIVisualEffectView!
     
     var player = AVPlayer()
-    let path = Bundle.main.path(forResource: "start", ofType: "mov")
-
+    var playerLayer = AVPlayerLayer()
+    
     override func viewDidLoad() {
         
         super.viewDidLoad()
+        
+        let path = Bundle.main.path(forResource: "start", ofType: "mov")
+        player = AVPlayer(url: URL(fileURLWithPath: path!))
 
+        playerLayer = AVPlayerLayer(player: player)
+
+        playerLayer.frame = view.bounds
+
+        print(view.bounds)
+
+        playerLayer.zPosition = -1
+        playerLayer.repeatCount = 0
+        playerLayer.videoGravity = .resizeAspectFill
+        playerLayer.needsDisplayOnBoundsChange = true
+        playerLayer.player?.isMuted = true
+        
+        
+        view.layer.insertSublayer(playerLayer, at: 0)
+
+        NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime, object: playerLayer.player?.currentItem, queue: .main){(_)in
+
+            self.player.seek(to: .zero)
+            self.player.play()
+        }
+
+        
+        self.player.play()
+        
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -29,7 +56,7 @@ class LoginMovieViewController: UIViewController {
         
         self.navigationController?.isNavigationBarHidden = false
         
-        setUpMoviePlayer()
+        
         
     }
     
@@ -83,33 +110,16 @@ class LoginMovieViewController: UIViewController {
         
         self.view.addConstraint(blurViewTralingConstraint)
         
+        playerLayer.frame = view.bounds
         
-        
-    }
-    
-    func setUpMoviePlayer(){
-        
-        player = AVPlayer(url: URL(fileURLWithPath: path!))
-        
-        //AVPlayer用のレイヤー作成
-        let playerLayer = AVPlayerLayer(player: player)
-        playerLayer.frame = CGRect(x: 0,
-                                   y: 0,
-                                   width: view.frame.size.width,
-                                   height: view.frame.size.height)
-        playerLayer.videoGravity = .resizeAspectFill
-        playerLayer.repeatCount = 0
-        playerLayer.zPosition = -1
-        view.layer.insertSublayer(playerLayer, at: 0)
-        
-        self.player.isMuted = true
         self.player.play()
         
     }
     
     @IBAction func login(_ sender: Any) {
         
-        player.pause()
+        self.player.pause()
+        
         
     }
 

--- a/Swift5IntroApp1/Controller/NewsPageViewController.swift
+++ b/Swift5IntroApp1/Controller/NewsPageViewController.swift
@@ -43,17 +43,20 @@ class NewsPageViewController: UITableViewController, SegementSlideContentScrollV
         //画像をtableViewの下に置く
         //画像を呼び出す
         let image = UIImage(named: imageName)
+        
         //イメージビューを生成する
-        let imageView = UIImageView(frame: CGRect(x: 0,
-                                                  y: 0,
-                                                  width: self.tableView.bounds.size.width,
-                                                  height: self.tableView.bounds.size.height))
+        let imageView = UIImageView(frame: CGRect.zero)
         
         //イメージビューに画像をセットする
         imageView.image = image
         
         //tableViewの背景にイメージビューをセットする
         self.tableView.backgroundView = imageView
+        
+        imageView.topAnchor.constraint(equalTo: self.tableView.topAnchor).isActive = true
+        imageView.leadingAnchor.constraint(equalTo: self.tableView.leadingAnchor).isActive = true
+        imageView.trailingAnchor.constraint(equalTo: self.tableView.trailingAnchor).isActive = true
+        imageView.bottomAnchor.constraint(equalTo: self.tableView.bottomAnchor).isActive = true
         
         //XMLパース
         let url = URL(string: urlString)!

--- a/Swift5IntroApp1/Controller/NewsPageViewController.swift
+++ b/Swift5IntroApp1/Controller/NewsPageViewController.swift
@@ -44,7 +44,10 @@ class NewsPageViewController: UITableViewController, SegementSlideContentScrollV
         //画像を呼び出す
         let image = UIImage(named: imageName)
         //イメージビューを生成する
-        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: self.tableView.frame.size.width, height: self.tableView.frame.size.height))
+        let imageView = UIImageView(frame: CGRect(x: 0,
+                                                  y: 0,
+                                                  width: self.tableView.bounds.size.width,
+                                                  height: self.tableView.bounds.size.height))
         
         //イメージビューに画像をセットする
         imageView.image = image

--- a/Swift5IntroApp1/View/Base.lproj/Main.storyboard
+++ b/Swift5IntroApp1/View/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Intro View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="IntroViewController" customModule="Swift5IntroApp1" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="intro" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="IntroViewController" customModule="Swift5IntroApp1" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -22,12 +22,14 @@
                                 <viewLayoutGuide key="contentLayoutGuide" id="xYj-qa-kTR"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="RZX-Up-drQ"/>
                             </scrollView>
-                            <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5l6-i6-bRW">
-                                <rect key="frame" x="162" y="138" width="90" height="39"/>
+                            <button opaque="NO" contentMode="scaleAspectFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5l6-i6-bRW">
+                                <rect key="frame" x="46" y="139" width="82" height="36"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemRedColor"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                 <state key="normal" title="スキップ">
                                     <color key="titleColor" systemColor="labelColor"/>
+                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default"/>
                                 </state>
                                 <connections>
                                     <segue destination="mYF-vp-ZsK" kind="show" id="J3U-jg-nu7"/>
@@ -36,10 +38,6 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="5l6-i6-bRW" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="koA-mC-gpy"/>
-                            <constraint firstItem="5l6-i6-bRW" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="50" id="mCN-8X-KuS"/>
-                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="TUH-3H-GLC"/>
                     <connections>
@@ -69,10 +67,7 @@
                                 <blurEffect style="regular"/>
                             </visualEffectView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hi" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NEi-tT-fHs">
-                                <rect key="frame" x="159" y="282" width="96" height="48"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="NEi-tT-fHs" secondAttribute="height" multiplier="2:1" id="DGv-ej-4ty"/>
-                                </constraints>
+                                <rect key="frame" x="159" y="332" width="96" height="48"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="40"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -91,10 +86,11 @@
                         <viewLayoutGuide key="safeArea" id="onL-I2-Gf4"/>
                         <constraints>
                             <constraint firstAttribute="trailingMargin" secondItem="BUH-iN-avZ" secondAttribute="trailing" id="3FH-Hf-Dzl"/>
+                            <constraint firstItem="BUH-iN-avZ" firstAttribute="top" secondItem="NEi-tT-fHs" secondAttribute="bottom" constant="50" id="AFr-ys-kRb"/>
                             <constraint firstItem="NEi-tT-fHs" firstAttribute="centerX" secondItem="zSk-lF-1uY" secondAttribute="centerX" id="X6z-tR-eov"/>
                             <constraint firstItem="BUH-iN-avZ" firstAttribute="leading" secondItem="zSk-lF-1uY" secondAttribute="leadingMargin" id="dV9-yd-4px"/>
                             <constraint firstItem="BUH-iN-avZ" firstAttribute="centerY" secondItem="zSk-lF-1uY" secondAttribute="centerY" id="hdf-ZJ-5zA"/>
-                            <constraint firstItem="BUH-iN-avZ" firstAttribute="top" secondItem="NEi-tT-fHs" secondAttribute="bottom" constant="100" id="ibd-O6-Nvn"/>
+                            <constraint firstItem="NEi-tT-fHs" firstAttribute="width" secondItem="zSk-lF-1uY" secondAttribute="width" multiplier="0.231884" id="kle-wX-yrm"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="bNP-gK-EuK"/>

--- a/Swift5IntroApp1/View/Base.lproj/Main.storyboard
+++ b/Swift5IntroApp1/View/Base.lproj/Main.storyboard
@@ -19,35 +19,32 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uRJ-r7-R7c">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemGreenColor"/>
                                 <viewLayoutGuide key="contentLayoutGuide" id="xYj-qa-kTR"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="RZX-Up-drQ"/>
                             </scrollView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5l6-i6-bRW">
-                                <rect key="frame" x="304" y="98" width="90" height="39"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="5l6-i6-bRW" secondAttribute="height" multiplier="30:13" id="zaf-Ya-9FE"/>
-                                </constraints>
+                            <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5l6-i6-bRW">
+                                <rect key="frame" x="162" y="138" width="90" height="39"/>
+                                <color key="backgroundColor" systemColor="systemRedColor"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                 <state key="normal" title="スキップ">
                                     <color key="titleColor" systemColor="labelColor"/>
                                 </state>
                                 <connections>
-                                    <segue destination="mYF-vp-ZsK" kind="show" id="HL0-G9-oAl"/>
+                                    <segue destination="mYF-vp-ZsK" kind="show" id="J3U-jg-nu7"/>
                                 </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="5l6-i6-bRW" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="2GM-ro-1X5"/>
-                            <constraint firstItem="5l6-i6-bRW" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.217391" id="Z8t-2p-NM0"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="5l6-i6-bRW" secondAttribute="trailing" constant="20" id="tgI-1o-Bot"/>
+                            <constraint firstItem="5l6-i6-bRW" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="koA-mC-gpy"/>
+                            <constraint firstItem="5l6-i6-bRW" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="50" id="mCN-8X-KuS"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="TUH-3H-GLC"/>
                     <connections>
                         <outlet property="scrollView" destination="uRJ-r7-R7c" id="pf7-iA-DRD"/>
+                        <outlet property="skipButton" destination="5l6-i6-bRW" id="dWM-kM-E6c"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -58,28 +55,31 @@
         <scene sceneID="fVR-EX-I8h">
             <objects>
                 <viewController modalTransitionStyle="crossDissolve" id="mYF-vp-ZsK" customClass="LoginMovieViewController" customModule="Swift5IntroApp1" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" ambiguous="YES" id="zSk-lF-1uY">
+                    <view key="view" contentMode="scaleToFill" id="zSk-lF-1uY">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <visualEffectView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GdT-mj-4OV">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="950"/>
-                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="yg4-w8-9DO">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="950"/>
+                            <visualEffectView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eGY-n2-Yt2">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="3pM-3g-Wrk">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                                 <blurEffect style="regular"/>
                             </visualEffectView>
-                            <view opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="U8j-MB-WYq">
-                                <rect key="frame" x="0.0" y="-27" width="414" height="950"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            </view>
-                            <button opaque="NO" alpha="0.80000000000000004" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BUH-iN-avZ">
-                                <rect key="frame" x="107" y="430" width="200" height="36"/>
-                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hi" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NEi-tT-fHs">
+                                <rect key="frame" x="159" y="282" width="96" height="48"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="BUH-iN-avZ" secondAttribute="height" multiplier="50:9" id="CN4-wW-sAh"/>
+                                    <constraint firstAttribute="width" secondItem="NEi-tT-fHs" secondAttribute="height" multiplier="2:1" id="DGv-ej-4ty"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="40"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" alpha="0.80000000000000004" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BUH-iN-avZ">
+                                <rect key="frame" x="20" y="430" width="374" height="36"/>
+                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                 <state key="normal" title="ログイン"/>
                                 <connections>
@@ -87,34 +87,19 @@
                                     <segue destination="NQo-Ay-nZh" kind="show" id="oyM-3P-pTU"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Hi" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NEi-tT-fHs">
-                                <rect key="frame" x="187" y="224" width="40" height="48"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="NEi-tT-fHs" secondAttribute="height" multiplier="5:6" id="cLf-Hr-Yl9"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="40"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="onL-I2-Gf4"/>
                         <constraints>
-                            <constraint firstAttribute="bottomMargin" secondItem="GdT-mj-4OV" secondAttribute="bottom" constant="-88" id="3cx-9i-s5O"/>
-                            <constraint firstItem="BUH-iN-avZ" firstAttribute="centerY" secondItem="U8j-MB-WYq" secondAttribute="centerY" id="5eo-lO-eNR"/>
-                            <constraint firstItem="BUH-iN-avZ" firstAttribute="centerX" secondItem="NEi-tT-fHs" secondAttribute="centerX" id="BOR-f3-aSN"/>
-                            <constraint firstItem="GdT-mj-4OV" firstAttribute="leading" secondItem="U8j-MB-WYq" secondAttribute="leading" id="Fld-kQ-JAS"/>
-                            <constraint firstItem="NEi-tT-fHs" firstAttribute="width" secondItem="zSk-lF-1uY" secondAttribute="width" multiplier="0.0966184" id="TCc-L2-rrS"/>
-                            <constraint firstItem="GdT-mj-4OV" firstAttribute="height" secondItem="zSk-lF-1uY" secondAttribute="height" multiplier="1.06027" id="V0S-eA-vnk"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="BUH-iN-avZ" secondAttribute="trailing" id="3FH-Hf-Dzl"/>
                             <constraint firstItem="NEi-tT-fHs" firstAttribute="centerX" secondItem="zSk-lF-1uY" secondAttribute="centerX" id="X6z-tR-eov"/>
-                            <constraint firstItem="NEi-tT-fHs" firstAttribute="centerY" secondItem="zSk-lF-1uY" secondAttribute="centerY" constant="-200" id="hzA-it-Qkp"/>
-                            <constraint firstItem="BUH-iN-avZ" firstAttribute="centerX" secondItem="GdT-mj-4OV" secondAttribute="centerX" id="nw3-dG-rSS"/>
-                            <constraint firstItem="GdT-mj-4OV" firstAttribute="top" secondItem="zSk-lF-1uY" secondAttribute="topMargin" constant="-88" id="uib-VR-m2R"/>
-                            <constraint firstItem="BUH-iN-avZ" firstAttribute="width" secondItem="zSk-lF-1uY" secondAttribute="width" multiplier="0.483092" id="v2Y-He-Aji"/>
+                            <constraint firstItem="BUH-iN-avZ" firstAttribute="leading" secondItem="zSk-lF-1uY" secondAttribute="leadingMargin" id="dV9-yd-4px"/>
+                            <constraint firstItem="BUH-iN-avZ" firstAttribute="centerY" secondItem="zSk-lF-1uY" secondAttribute="centerY" id="hdf-ZJ-5zA"/>
+                            <constraint firstItem="BUH-iN-avZ" firstAttribute="top" secondItem="NEi-tT-fHs" secondAttribute="bottom" constant="100" id="ibd-O6-Nvn"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="bNP-gK-EuK"/>
                     <connections>
-                        <outlet property="blurView" destination="GdT-mj-4OV" id="vDZ-Ca-vXF"/>
+                        <outlet property="blurView" destination="eGY-n2-Yt2" id="XdR-Al-WEc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lab-a2-Iae" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -166,8 +151,8 @@
         <systemColor name="systemGray6Color">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
-        <systemColor name="systemGreenColor">
-            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
# 概要

#2 

複数機種のレイアウト対応


## 変更点

以下、各機種ごとの画面比較表になります

|iPhoneSE <br>(2nd generation)|iPhone11|iPad <br>(8th generation)|
|:---:|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/82574685/115638318-298f5280-a34d-11eb-8687-08e14884a0a2.png" width = "187.5px" height = "333.5px">|<img src ="https://user-images.githubusercontent.com/82574685/115638550-930f6100-a34d-11eb-8c00-a7ce953aeec5.png" width = "207px" height = "448px">|<img src = "https://user-images.githubusercontent.com/82574685/115638658-c651f000-a34d-11eb-8d50-2acb9285a3af.png" width = "405px" height = "540px">|
|<img src ="https://user-images.githubusercontent.com/82574685/115639275-25fccb00-a34f-11eb-935c-f9012c6fd499.png" width = "187.5px" height = "333.5px">|<img src ="https://user-images.githubusercontent.com/82574685/115639312-3b71f500-a34f-11eb-9768-9226c9f72c1a.png" width = "207px" height = "448px">|<img src ="https://user-images.githubusercontent.com/82574685/115639377-60fefe80-a34f-11eb-925b-5255841743c2.png" width = "405px" height = "540px">|
|<img src ="https://user-images.githubusercontent.com/82574685/115645656-b2ad8600-a35b-11eb-9993-60e713581198.png" width = "187.5px" height = "333.5px">|<img src = "https://user-images.githubusercontent.com/82574685/115643926-9f4ceb80-a358-11eb-9dd1-301423c6f8dd.png" width ="207px" height = "448px">|<img src = "https://user-images.githubusercontent.com/82574685/115644240-31ed8a80-a359-11eb-84e4-930b814442a8.png" width = "405px" height = "540px"> |

## 懸念点

- 戻るボタンを押すと、
    - jsonアニメーションが止まっている(ライブラリのドキュメント確認必要)
    - ログイン画面の動画が止まったまま(AVFoundationの使い方確認必要)



