### PR TITLE
Fix #19 (UserDefaults -> VCに値渡しへ変更) #21(urlStringをModelに分ける)

### DIFF
--- a/Swift5IntroApp1.xcodeproj/project.pbxproj
+++ b/Swift5IntroApp1.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		CE47D0F726294BC5009F0B82 /* 3.json in Resources */ = {isa = PBXBuildFile; fileRef = CE47D0F226294BC5009F0B82 /* 3.json */; };
 		CE47D0FB26294C48009F0B82 /* IntroViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE47D0FA26294C48009F0B82 /* IntroViewController.swift */; };
 		CE58CE102632C8BD00968EAD /* JSONModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE58CE0F2632C8BD00968EAD /* JSONModel.swift */; };
-		CEB074602629B84C000E9D0F /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB0745F2629B84C000E9D0F /* BaseViewController.swift */; };
+		CEB074602629B84C000E9D0F /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB0745F2629B84C000E9D0F /* HomeViewController.swift */; };
 		CEB074672629BB7C000E9D0F /* NewsPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB074662629BB7C000E9D0F /* NewsPageViewController.swift */; };
 		CEB0746D2629D0D0000E9D0F /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB0746C2629D0D0000E9D0F /* WebViewController.swift */; };
 		CEC42F4D264A3563009FD7A5 /* URLModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC42F4C264A3563009FD7A5 /* URLModel.swift */; };
@@ -48,7 +48,7 @@
 		CE47D0F226294BC5009F0B82 /* 3.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 3.json; sourceTree = "<group>"; };
 		CE47D0FA26294C48009F0B82 /* IntroViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewController.swift; sourceTree = "<group>"; };
 		CE58CE0F2632C8BD00968EAD /* JSONModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONModel.swift; sourceTree = "<group>"; };
-		CEB0745F2629B84C000E9D0F /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		CEB0745F2629B84C000E9D0F /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		CEB074662629BB7C000E9D0F /* NewsPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsPageViewController.swift; sourceTree = "<group>"; };
 		CEB0746C2629D0D0000E9D0F /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		CEC42F4C264A3563009FD7A5 /* URLModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = URLModel.swift; path = Swift5IntroApp1/Model/URLModel.swift; sourceTree = SOURCE_ROOT; };
@@ -147,7 +147,7 @@
 				CE0C11B2262421D700D24B86 /* SceneDelegate.swift */,
 				CE47D0FA26294C48009F0B82 /* IntroViewController.swift */,
 				CE3C1B4426296BEF0040C259 /* LoginMovieViewController.swift */,
-				CEB0745F2629B84C000E9D0F /* BaseViewController.swift */,
+				CEB0745F2629B84C000E9D0F /* HomeViewController.swift */,
 				CEB074662629BB7C000E9D0F /* NewsPageViewController.swift */,
 				CEB0746C2629D0D0000E9D0F /* WebViewController.swift */,
 			);
@@ -275,7 +275,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CEECE8DF264A583D003A8343 /* TitleInSwitcherModel.swift in Sources */,
-				CEB074602629B84C000E9D0F /* BaseViewController.swift in Sources */,
+				CEB074602629B84C000E9D0F /* HomeViewController.swift in Sources */,
 				CE47D0FB26294C48009F0B82 /* IntroViewController.swift in Sources */,
 				CE3C1B4526296BEF0040C259 /* LoginMovieViewController.swift in Sources */,
 				CE58CE102632C8BD00968EAD /* JSONModel.swift in Sources */,

--- a/Swift5IntroApp1.xcodeproj/project.pbxproj
+++ b/Swift5IntroApp1.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		CEB074602629B84C000E9D0F /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB0745F2629B84C000E9D0F /* BaseViewController.swift */; };
 		CEB074672629BB7C000E9D0F /* NewsPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB074662629BB7C000E9D0F /* NewsPageViewController.swift */; };
 		CEB0746D2629D0D0000E9D0F /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB0746C2629D0D0000E9D0F /* WebViewController.swift */; };
+		CEC42F4D264A3563009FD7A5 /* URLModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC42F4C264A3563009FD7A5 /* URLModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -49,6 +50,7 @@
 		CEB0745F2629B84C000E9D0F /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		CEB074662629BB7C000E9D0F /* NewsPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsPageViewController.swift; sourceTree = "<group>"; };
 		CEB0746C2629D0D0000E9D0F /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
+		CEC42F4C264A3563009FD7A5 /* URLModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = URLModel.swift; path = Swift5IntroApp1/Model/URLModel.swift; sourceTree = SOURCE_ROOT; };
 		DB2CACB753C081A9A16EEBD8 /* Pods-Swift5IntroApp1.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Swift5IntroApp1.release.xcconfig"; path = "Target Support Files/Pods-Swift5IntroApp1/Pods-Swift5IntroApp1.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -120,6 +122,7 @@
 			isa = PBXGroup;
 			children = (
 				CE58CE0F2632C8BD00968EAD /* JSONModel.swift */,
+				CEC42F4C264A3563009FD7A5 /* URLModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -272,6 +275,7 @@
 				CE47D0FB26294C48009F0B82 /* IntroViewController.swift in Sources */,
 				CE3C1B4526296BEF0040C259 /* LoginMovieViewController.swift in Sources */,
 				CE58CE102632C8BD00968EAD /* JSONModel.swift in Sources */,
+				CEC42F4D264A3563009FD7A5 /* URLModel.swift in Sources */,
 				CE0C11B1262421D700D24B86 /* AppDelegate.swift in Sources */,
 				CEB074672629BB7C000E9D0F /* NewsPageViewController.swift in Sources */,
 				CE0C11B3262421D700D24B86 /* SceneDelegate.swift in Sources */,

--- a/Swift5IntroApp1.xcodeproj/project.pbxproj
+++ b/Swift5IntroApp1.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		CEB074672629BB7C000E9D0F /* NewsPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB074662629BB7C000E9D0F /* NewsPageViewController.swift */; };
 		CEB0746D2629D0D0000E9D0F /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB0746C2629D0D0000E9D0F /* WebViewController.swift */; };
 		CEC42F4D264A3563009FD7A5 /* URLModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC42F4C264A3563009FD7A5 /* URLModel.swift */; };
+		CEECE8DF264A583D003A8343 /* TitleInSwitcherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEECE8DE264A583D003A8343 /* TitleInSwitcherModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +52,7 @@
 		CEB074662629BB7C000E9D0F /* NewsPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsPageViewController.swift; sourceTree = "<group>"; };
 		CEB0746C2629D0D0000E9D0F /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		CEC42F4C264A3563009FD7A5 /* URLModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = URLModel.swift; path = Swift5IntroApp1/Model/URLModel.swift; sourceTree = SOURCE_ROOT; };
+		CEECE8DE264A583D003A8343 /* TitleInSwitcherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleInSwitcherModel.swift; sourceTree = "<group>"; };
 		DB2CACB753C081A9A16EEBD8 /* Pods-Swift5IntroApp1.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Swift5IntroApp1.release.xcconfig"; path = "Target Support Files/Pods-Swift5IntroApp1/Pods-Swift5IntroApp1.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -123,6 +125,7 @@
 			children = (
 				CE58CE0F2632C8BD00968EAD /* JSONModel.swift */,
 				CEC42F4C264A3563009FD7A5 /* URLModel.swift */,
+				CEECE8DE264A583D003A8343 /* TitleInSwitcherModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -271,6 +274,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CEECE8DF264A583D003A8343 /* TitleInSwitcherModel.swift in Sources */,
 				CEB074602629B84C000E9D0F /* BaseViewController.swift in Sources */,
 				CE47D0FB26294C48009F0B82 /* IntroViewController.swift in Sources */,
 				CE3C1B4526296BEF0040C259 /* LoginMovieViewController.swift in Sources */,

--- a/Swift5IntroApp1/Controller/BaseViewController.swift
+++ b/Swift5IntroApp1/Controller/BaseViewController.swift
@@ -6,6 +6,9 @@ import ImpressiveNotifications
 
 
 class BaseViewController: SegementSlideDefaultViewController {
+    
+    
+    let words = ["Swift","CocoaPods","Carthage","Xcode","SwiftUI","アーキテクチャ"]
 
     var urlModel = URLModel()
     
@@ -56,11 +59,11 @@ class BaseViewController: SegementSlideDefaultViewController {
     }
 
     override var titlesInSwitcher: [String] {
-        return urlModel.words
+        return words
     }
     
     override func segementSlideContentViewController(at index: Int) -> SegementSlideContentScrollViewDelegate? {
-        urlModel.setupURL(index: index)
+        urlModel.setupURL(word: words[index])
         return NewsPageViewController(urlString: urlModel.encodeUrlString)
     }
 

--- a/Swift5IntroApp1/Controller/BaseViewController.swift
+++ b/Swift5IntroApp1/Controller/BaseViewController.swift
@@ -61,34 +61,27 @@ class BaseViewController: SegementSlideDefaultViewController {
     
     override func segementSlideContentViewController(at index: Int) -> SegementSlideContentScrollViewDelegate? {
 
-        let urlString:String
+        var urlModel:URLModel
 
         switch index {
 
         case 0:
-            urlString = "https://qiita.com/api/v2/items?query=\(words[0])"
-
+            urlModel = URLModel(word: self.words[0])
         case 1:
-            urlString = "https://qiita.com/api/v2/items?query=\(words[1])"
-
+            urlModel = URLModel(word: self.words[1])
         case 2:
-            urlString = "https://qiita.com/api/v2/items?query=\(words[2])"
-
+            urlModel = URLModel(word: self.words[2])
         case 3:
-            urlString = "https://qiita.com/api/v2/items?query=\(words[3])"
-
+            urlModel = URLModel(word: self.words[3])
         case 4:
-            urlString = "https://qiita.com/api/v2/items?query=\(words[4])"
-
+            urlModel = URLModel(word: self.words[4])
         case 5:
-            urlString = "https://qiita.com/api/v2/items?query=\(words[5])"
-
+            urlModel = URLModel(word: self.words[5])
         default:
-            urlString = "https://qiita.com/api/v2/items?query=\(words[0])"
-
+            urlModel = URLModel(word: self.words[0])
         }
 
-        return NewsPageViewController(urlString: urlString)
+        return NewsPageViewController(urlString: urlModel.url)
 
     }
 

--- a/Swift5IntroApp1/Controller/BaseViewController.swift
+++ b/Swift5IntroApp1/Controller/BaseViewController.swift
@@ -7,8 +7,7 @@ import ImpressiveNotifications
 
 class BaseViewController: SegementSlideDefaultViewController {
     
-    
-    let words = ["Swift","CocoaPods","Carthage","Xcode","SwiftUI","アーキテクチャ"]
+    var titleInSwitcherModel = TitleInSwitcherModel()
 
     var urlModel = URLModel()
     
@@ -59,11 +58,11 @@ class BaseViewController: SegementSlideDefaultViewController {
     }
 
     override var titlesInSwitcher: [String] {
-        return words
+        return titleInSwitcherModel.words
     }
     
     override func segementSlideContentViewController(at index: Int) -> SegementSlideContentScrollViewDelegate? {
-        urlModel.setupURL(word: words[index])
+        urlModel.setupURL(word: titleInSwitcherModel.words[index])
         return NewsPageViewController(urlString: urlModel.encodeUrlString)
     }
 

--- a/Swift5IntroApp1/Controller/BaseViewController.swift
+++ b/Swift5IntroApp1/Controller/BaseViewController.swift
@@ -7,7 +7,7 @@ import ImpressiveNotifications
 
 class BaseViewController: SegementSlideDefaultViewController {
 
-    let words = ["Swift","CocoaPods","Carthage","Xcode","SwiftUI","アーキテクチャ"]
+    var urlModel = URLModel()
     
     override func viewDidLoad() {
 
@@ -56,33 +56,12 @@ class BaseViewController: SegementSlideDefaultViewController {
     }
 
     override var titlesInSwitcher: [String] {
-        return words
+        return urlModel.words
     }
     
     override func segementSlideContentViewController(at index: Int) -> SegementSlideContentScrollViewDelegate? {
-
-        var urlModel:URLModel
-
-        switch index {
-
-        case 0:
-            urlModel = URLModel(word: self.words[0])
-        case 1:
-            urlModel = URLModel(word: self.words[1])
-        case 2:
-            urlModel = URLModel(word: self.words[2])
-        case 3:
-            urlModel = URLModel(word: self.words[3])
-        case 4:
-            urlModel = URLModel(word: self.words[4])
-        case 5:
-            urlModel = URLModel(word: self.words[5])
-        default:
-            urlModel = URLModel(word: self.words[0])
-        }
-
-        return NewsPageViewController(urlString: urlModel.url)
-
+        urlModel.setupURL(index: index)
+        return NewsPageViewController(urlString: urlModel.encodeUrlString)
     }
 
 }

--- a/Swift5IntroApp1/Controller/HomeViewController.swift
+++ b/Swift5IntroApp1/Controller/HomeViewController.swift
@@ -5,7 +5,7 @@ import ImpressiveNotifications
 //ニュース記事一覧画面
 
 
-class BaseViewController: SegementSlideDefaultViewController {
+class HomeViewController: SegementSlideDefaultViewController {
     
     var titleInSwitcherModel = TitleInSwitcherModel()
 

--- a/Swift5IntroApp1/Controller/NewsPageViewController.swift
+++ b/Swift5IntroApp1/Controller/NewsPageViewController.swift
@@ -62,7 +62,7 @@ class NewsPageViewController: UITableViewController, SegementSlideContentScrollV
         
         let cell = UITableViewCell(style: .default, reuseIdentifier: "Cell")
         
-        let article = self.jsonDataArray[indexPath.row]
+        let article = jsonDataArray[indexPath.row]
         
         cell.backgroundColor = .systemGreen
         cell.textLabel?.text = article.title
@@ -79,13 +79,11 @@ class NewsPageViewController: UITableViewController, SegementSlideContentScrollV
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
-        let article = jsonDataArray[indexPath.row]
-        UserDefaults.standard.set(article.url, forKey: "url")
-        
         //１：遷移先の設定
         let nextPageController: WebViewController = WebViewController()
-        //２：トランジションの指定
+        //２：トランジションの指定,渡すURLを準備
         nextPageController.modalTransitionStyle = .coverVertical
+        nextPageController.urlString = jsonDataArray[indexPath.row].url
         //３：ナビゲーションコントローラーを生成
         let navigationController = UINavigationController(rootViewController: nextPageController)
         //４：次の画面へGO

--- a/Swift5IntroApp1/Controller/WebViewController.swift
+++ b/Swift5IntroApp1/Controller/WebViewController.swift
@@ -13,6 +13,7 @@ import WebKit
 class WebViewController: UIViewController,WKUIDelegate, WKNavigationDelegate {
     
     var webView = WKWebView()
+    var urlString:String = ""
     
     //Webサイト表示画面
     fileprivate func setupWebView() {
@@ -40,8 +41,7 @@ class WebViewController: UIViewController,WKUIDelegate, WKNavigationDelegate {
         
         setupWebView()
         
-        let urlString = UserDefaults.standard.object(forKey: "url")
-        let url = URL(string: urlString as! String)
+        let url = URL(string: urlString)
         let request = URLRequest(url: url!)
         
         webView.load(request)

--- a/Swift5IntroApp1/Controller/WebViewController.swift
+++ b/Swift5IntroApp1/Controller/WebViewController.swift
@@ -13,7 +13,7 @@ import WebKit
 class WebViewController: UIViewController,WKUIDelegate, WKNavigationDelegate {
     
     var webView = WKWebView()
-    var urlString:String = ""
+    var urlString: String = ""
     
     //Webサイト表示画面
     fileprivate func setupWebView() {

--- a/Swift5IntroApp1/Model/TitleInSwitcherModel.swift
+++ b/Swift5IntroApp1/Model/TitleInSwitcherModel.swift
@@ -1,0 +1,12 @@
+//
+//  TitleInSwitcherModel.swift
+//  Swift5IntroApp1
+//
+//  Created by user on 2021/05/11.
+//
+
+import Foundation
+
+struct TitleInSwitcherModel {
+    let words = ["Swift","CocoaPods","Carthage","Xcode","SwiftUI","アーキテクチャ"]
+}

--- a/Swift5IntroApp1/Model/URLModel.swift
+++ b/Swift5IntroApp1/Model/URLModel.swift
@@ -10,9 +10,9 @@ import Foundation
 struct URLModel{
     
     var url = "https://qiita.com/api/v2/items?query="
-    let word:String!
+    let word: String!
     
-    init(word:String){
+    init(word: String){
         self.word = word
         self.url = self.url + self.word
     }

--- a/Swift5IntroApp1/Model/URLModel.swift
+++ b/Swift5IntroApp1/Model/URLModel.swift
@@ -10,13 +10,13 @@ import Foundation
 struct URLModel{
     
     var baseUrl = "https://qiita.com/api/v2/items?query="
-    let words = ["Swift","CocoaPods","Carthage","Xcode","SwiftUI","アーキテクチャ"]
     var searchUrl = ""
     var encodeUrlString = ""
     
-    mutating func setupURL(index: Int){
+    //BaseVCからキーワードを受け取り、URLを生成する
+    mutating func setupURL(word: String){
         
-        self.searchUrl = self.baseUrl + self.words[index]
+        self.searchUrl = self.baseUrl + word
         self.encodeUrlString = self.searchUrl.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
     
     }

--- a/Swift5IntroApp1/Model/URLModel.swift
+++ b/Swift5IntroApp1/Model/URLModel.swift
@@ -1,0 +1,20 @@
+//
+//  URLs.swift
+//  Swift5IntroApp1
+//
+//  Created by user on 2021/05/10.
+//
+
+import Foundation
+
+struct URLModel{
+    
+    var url = "https://qiita.com/api/v2/items?query="
+    let word:String!
+    
+    init(word:String){
+        self.word = word
+        self.url = self.url + self.word
+    }
+    
+}

--- a/Swift5IntroApp1/Model/URLModel.swift
+++ b/Swift5IntroApp1/Model/URLModel.swift
@@ -9,12 +9,16 @@ import Foundation
 
 struct URLModel{
     
-    var url = "https://qiita.com/api/v2/items?query="
-    let word: String!
+    var baseUrl = "https://qiita.com/api/v2/items?query="
+    let words = ["Swift","CocoaPods","Carthage","Xcode","SwiftUI","アーキテクチャ"]
+    var searchUrl = ""
+    var encodeUrlString = ""
     
-    init(word: String){
-        self.word = word
-        self.url = self.url + self.word
+    mutating func setupURL(index: Int){
+        
+        self.searchUrl = self.baseUrl + self.words[index]
+        self.encodeUrlString = self.searchUrl.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+    
     }
     
 }


### PR DESCRIPTION
## 概要
### #19
- URLデータの受け渡し方法の変更 

### #21
- URLをControllerからModelへ移行

## 変更点
### #19 
- UserDefaultは使わない
- NavigationController経由でWebViewControllerへURLを渡す

### #21 
- URLModelを作成（URLのひな型として使う）

## 懸念点
- SegementSlideのスイッチャー名はまだViewController上に存在するので、完全にModel化は出来ていない
